### PR TITLE
POL-135: add relation between bill and committee

### DIFF
--- a/api/src/schema.graphql
+++ b/api/src/schema.graphql
@@ -162,10 +162,10 @@ type Bill{
     beSubmittedByMembers: [Member!]! @relation(name: "MEMBER_SUBMIT_BILL", direction: "IN")
     beReceivedByDiet: Diet @relation(name: "DIET_RECEIVE_BILL", direction: "IN")
     beDiscussedByMinutes: [Minutes!]! @relation(name: "MINUTES_DISCUSS_BILL", direction: "IN")
+    belongedToCommittees: [Committee!]! @relation(name: "BILL_BELONG_TO_COMMITTEE", direction: "OUT")
     amendedLaws: [Law!]! @relation(name: "BILL_AMEND_LAW", direction: "OUT")
     urls: [Url!]! @relation(name: "URL_REFER_BILL", direction: "IN")
     news: [News!]! @relation(name: "NEWS_REFER_BILL", direction: "IN")
-    beReferredToCommittee: [Committee!]! @relation(name: "COMMITTEE_REFER_BILL", direction: "OUT")
     submittedDate: DateTime
     passedRepresentativesCommitteeDate: DateTime
     passedRepresentativesDate: DateTime
@@ -204,7 +204,7 @@ type Committee{
     tags: [String!]
     members: [Member!]! @relation(name: "MEMBER_BELONG_TO_COMMITTEE", direction: "IN")
     minutes: [Minutes!]! @relation(name: "MINUTES_BELONG_TO_COMMITTEE", direction: "IN")
-    bills: [Bill!]! @relation(name: "COMMITTEE_REFER_BILL", direction: "IN")
+    bills: [Bill!]! @relation(name: "BILL_BELONG_TO_COMMITTEE", direction: "IN")
 
     totalMinutes: Int! @cypher(
         statement: """MATCH (this)-[]-(m:Minutes)

--- a/api/src/schema.graphql
+++ b/api/src/schema.graphql
@@ -165,6 +165,7 @@ type Bill{
     amendedLaws: [Law!]! @relation(name: "BILL_AMEND_LAW", direction: "OUT")
     urls: [Url!]! @relation(name: "URL_REFER_BILL", direction: "IN")
     news: [News!]! @relation(name: "NEWS_REFER_BILL", direction: "IN")
+    beReferredToCommittee: [Committee!]! @relation(name: "COMMITTEE_REFER_BILL", direction: "OUT")
     submittedDate: DateTime
     passedRepresentativesCommitteeDate: DateTime
     passedRepresentativesDate: DateTime
@@ -203,6 +204,7 @@ type Committee{
     tags: [String!]
     members: [Member!]! @relation(name: "MEMBER_BELONG_TO_COMMITTEE", direction: "IN")
     minutes: [Minutes!]! @relation(name: "MINUTES_BELONG_TO_COMMITTEE", direction: "IN")
+    bills: [Bill!]! @relation(name: "COMMITTEE_REFER_BILL", direction: "IN")
 
     totalMinutes: Int! @cypher(
         statement: """MATCH (this)-[]-(m:Minutes)


### PR DESCRIPTION
BillとCommitteeの間にrelationを定義した。
BillのbeReferredToCommitteeが配列なのは、衆議院の付託委員会と参議院の付託委員会が存在するため。